### PR TITLE
feat: add sqlite cache for top items

### DIFF
--- a/db/sqlite.js
+++ b/db/sqlite.js
@@ -1,0 +1,15 @@
+import sqlite3 from 'sqlite3';
+
+const db = new sqlite3.Database('cache.db');
+
+db.serialize(() => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS top_items (
+      id TEXT PRIMARY KEY,
+      data TEXT NOT NULL,
+      lastUpdated INTEGER NOT NULL
+    )
+  `);
+});
+
+export default db;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "15.4.7",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add SQLite database and table for cached top item data
- use 48h persisted cache in `/api/top-items`
- add sqlite3 dependency

## Testing
- `npm run lint` *(fails: React hook dependency warnings and unescaped entity)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8e6310d6c8320bf322952a409d9a1